### PR TITLE
Fix typos and show/hide music menu option correctly

### DIFF
--- a/mainmenu.xml
+++ b/mainmenu.xml
@@ -5,7 +5,7 @@
         <type>MENU_TV</type>
         <text>Watch TV</text>
         <text lang="DE">Fernsehen</text>
-        <description>Watch live TV or schedule recordeding</description>
+        <description>Watch live TV or schedule recordings</description>
         <description lang="DE">TV und Aufnahmen anschauen oder planen</description>
         <action>MENU menu/tv_menu.xml</action>
     </button>
@@ -26,6 +26,7 @@
         <description>Listen to your music or from the internet</description>
         <description lang="DE">Höre Deine Musik oder aus dem Internet</description>
         <action>MENU menu/music_menu.xml</action>
+        <depends>mythmusic</depends>
     </button>
 
     <button>

--- a/video-ui.xml
+++ b/video-ui.xml
@@ -98,7 +98,7 @@
             <area>20,675,1240,30</area>
             <multiline>yes</multiline>
             <align>allcenter</align>
-            <value>No videos in library or file are being loaded..."</value>
+            <value>No videos in library or files are being loaded...</value>
         </textarea>
 
         <!-- Show the title, season, episode and time -->


### PR DESCRIPTION
Fixed typos in main menu and video gallery, and make music option hide if mythmusic is not installed.
