### PR TITLE
Cut editor crammed on left side of screen

### DIFF
--- a/osd.xml
+++ b/osd.xml
@@ -1132,11 +1132,11 @@
             </shape>
 
             <shape name="keep">
-                <area>0,0,2,20</area>
+                <area>0,0,800,20</area>
                 <fill color="#3694ED" alpha="255" />
             </shape>
             <shape name="cut">
-                <area>0,0,2,20</area>
+                <area>0,0,800,20</area>
                 <fill color="#FF0000" alpha="255" />
             </shape>
 


### PR DESCRIPTION
First - thank you very much for creating this theme - I've been using it for quite awhile and really like how it looks.

Second - sorry for the multiple edits/opens on this ticket, its my first time using github.

I upgraded to 1.9 today and noticed a problem - the cut edit bar only uses the left few pixels.  I created this pull request to fix the issue.

This is the way the newly upgraded cut edit bar looked:
![screenshot-before](https://f.cloud.github.com/assets/3442309/116185/f7f286b6-6bec-11e2-9e24-162c9119765a.jpg)

After my fix:
![screenshot-after](https://f.cloud.github.com/assets/3442309/116189/119a09d6-6bed-11e2-9762-ee0bc1675a83.jpg)
