### PR TITLE
Various updates to music and gallery UI

### DIFF
--- a/image-ui.xml
+++ b/image-ui.xml
@@ -6,283 +6,14 @@
     <!-- Default screen that shows the the available images in a list -->
     <window name="gallery">
 
-        <imagetype name="fanart" from="base_background"/>
-        
-        <textarea name="heading" from="base_heading">
-            <position>0,0</position>
-            <textarea name="text">
-                <value>Image Gallery</value>
-            </textarea>
+        <!-- shows path to current image -->
+        <textarea name="breadcrumbs" from="base_textarea">
+            <area>25,670,770,30</area>
+            <scroll direction="horizontal" />
         </textarea>
-        
-        <shape name="gallery_background" from="base_background_shape">
-            <area>20,50,1240,570</area>
-        </shape>
-        
-        <textarea name="noimages" from="base_textarea">
-            <area>220,50,840,570</area>
-            <align>allcenter</align>
-        </textarea>
-        
-        <buttonlist name="images">
-            <area>35,65,1220,540</area>
-            <layout>grid</layout>
-            <spacing>2</spacing>
-            <wrapstyle>flowing</wrapstyle>
-            <buttonarea>0,0,100%,100%</buttonarea>
-
-            <statetype name="buttonitem">
-                <state name="active">
-                   
-                    <!-- Shows the name of the item over a black background -->
-                    <shape name="buttontext_background" from="base_background_shape">
-                        <area>3,99,127,31</area>
-                        <line color="#AAAAAA" alpha="0" width="0" />
-                    </shape>
-                    <textarea name="buttontext" from="base_textarea">
-                        <area>10,105,110,20</area>
-                        <font>text_small</font>
-                        <multiline>yes</multiline>
-                        <align>allcenter</align>
-                    </textarea>
-
-                    <!-- Shows the background image (if no thumbnail is available) or 
-                         the actual thumbnail image and a border around it -->
-                    <imagetype name="background_image">
-                        <area>0,0,133,133</area>
-                        <mask>images/media/image_item_nfmask.png</mask>
-                        <filename>images/media/image_item_bg.png</filename>
-                        <preserveaspect>true</preserveaspect>
-                    </imagetype>
-
-                    <imagetype name="thumbimage1">
-                        <area>10,10,60,45</area>
-                        <preserveaspect>false</preserveaspect>
-                    </imagetype>
-                    <imagetype name="thumbimage2">
-                        <area>66,10,60,45</area>
-                        <preserveaspect>false</preserveaspect>
-                    </imagetype>
-                    <imagetype name="thumbimage3">
-                        <area>10,55,60,45</area>
-                        <preserveaspect>false</preserveaspect>
-                    </imagetype>
-                    <imagetype name="thumbimage4">
-                        <area>66,55,60,45</area>
-                        <preserveaspect>false</preserveaspect>
-                    </imagetype>
-
-                    <imagetype name="buttonimage">
-                        <area>0,0,133,133</area>
-                        <mask>images/media/image_item_nfmask.png</mask>
-                        <preserveaspect>true</preserveaspect>
-                    </imagetype>
-
-                    <!-- Shows if the item is marked or not -->
-                    <statetype name="nodecheck">
-                        <position>96,3</position>
-                        <state name="full">
-                            <shape name="buttoncheck_background" from="base_background_shape">
-                                <area>0,0,34,34</area>
-                                <line color="#AAAAAA" alpha="0" width="0" />
-                            </shape>
-                            <imagetype name="checkfull" from="base_icon_selected">
-                                <area>4,3,28,28</area>
-                                <filename>images/icons/selected.png</filename>
-                            </imagetype>
-                        </state>
-                    </statetype>
-                    
-                    <!-- Shows if the item is either hidden or visible -->
-                    <statetype name="nodevisibility">
-                        <position>62,3</position>
-                        <state name="hidden">
-                            <shape name="buttoncheck_background" from="base_background_shape">
-                                <area>0,0,34,34</area>
-                                <line color="#AAAAAA" alpha="0" width="0" />
-                            </shape>
-                            <imagetype name="hidden" from="base_icon_selected">
-                                <area>4,3,28,28</area>
-                                <filename>images/icons/hidden.png</filename>
-                            </imagetype>
-                        </state>
-                    </statetype>
-
-                    <!-- Shows the type of the item. It can be either 
-                         a subfolder, upfolder, image or a video -->
-                    <statetype name="nodetype">
-                        <position>0,0</position>
-                        <state name="subfolder">
-                            <shape name="subfolder_background" from="base_background_shape">
-                                <area>2,2,129,36</area>
-                                <line color="#AAAAAA" alpha="0" width="0" />
-                            </shape>
-                            <imagetype name="subfolder_icon">
-                                <area>10,6,28,28</area>
-                                <filename>images/icons/folder_selected.png</filename>
-                            </imagetype>
-                        </state>
-                        <state name="upfolder">
-                            <imagetype name="upfolder_icon">
-                                <area>10,6,28,28</area>
-                                <filename>images/icons/folder_up_selected.png</filename>
-                            </imagetype>
-                        </state>
-                        <!-- Do not show something extra when the file 
-                             is an image. The image preview is enough -->
-                        <state name="image" />
-                        <state name="video">
-                            <imagetype name="videoimage_background">
-                                <area>0,0,133,133</area>
-                                <filename>images/media/image_item_video.png</filename>
-                                <mask>images/media/image_item_nfmask.png</mask>
-                            </imagetype>
-                        </state>
-                    </statetype>
-
-                    <imagetype name="background_image_border">
-                        <area>0,0,133,133</area>
-                        <filename>images/media/image_item_nfborder.png</filename>
-                    </imagetype>
-
-                    <textarea name="childcount" from="base_textarea" depends="subfolder_icon">
-                        <area>45,3,80,36</area>
-                    </textarea>
-
-                </state>
-
-                <!-- These two states are not used -->
-                <state name="inactive" from="active"/>
-                <state name="selectedinactive" from="active"/>
-                    
-                <state name="selectedactive" from="active">
-                    <area>-26,-26,133,133</area>
-                    
-                    <!-- Shows the name of the item over a black background -->
-                    <shape name="buttontext_background" from="base_background_shape_dark">
-                        <area>7,118,171,60</area>
-                        <line color="#AAAAAA" alpha="0" width="0" />
-                    </shape>
-                    <textarea name="buttontext" from="base_textarea">
-                        <area>20,131,145,42</area>
-                        <multiline>yes</multiline>
-                        <scroll direction="vertical" />
-                        <align>allcenter</align>
-                    </textarea>
-                    
-                    <!-- Shows the background image (if no thumbnail is available) or 
-                         the actual thumbnail image and a border around it -->
-                    <imagetype name="background_image">
-                        <area>0,0,185,185</area>
-                        <mask>images/media/image_item_fmask.png</mask>
-                        <filename>images/media/image_item_bg.png</filename>
-                    </imagetype>     
-
-                    <imagetype name="thumbimage1">
-                        <area>20,20,80,60</area>
-                        <preserveaspect>false</preserveaspect>
-                    </imagetype>
-                    <imagetype name="thumbimage2">
-                        <area>85,20,80,60</area>
-                        <preserveaspect>false</preserveaspect>
-                    </imagetype>
-                    <imagetype name="thumbimage3">
-                        <area>20,70,80,60</area>
-                        <preserveaspect>false</preserveaspect>
-                    </imagetype>
-                    <imagetype name="thumbimage4">
-                        <area>85,70,80,60</area>
-                        <preserveaspect>false</preserveaspect>
-                    </imagetype>
-
-                    <imagetype name="buttonimage">
-                        <area>0,0,185,185</area>
-                        <mask>images/media/image_item_fmask.png</mask>
-                        <preserveaspect>true</preserveaspect>
-                    </imagetype>
-
-                    <!-- Shows if the item is marked or not -->
-                    <statetype name="nodecheck">
-                        <position>143,7</position>
-                        <state name="full">
-                            <shape name="buttoncheck_background" from="base_background_shape">
-                                <area>0,0,36,36</area>
-                                <line color="#AAAAAA" alpha="0" width="0" />
-                            </shape>
-                            <imagetype name="checkfull" from="base_icon_selected">
-                                <area>3,3,30,30</area>
-                                <filename>images/icons/selected.png</filename>
-                            </imagetype>
-                        </state>
-                    </statetype>
-                    
-                    <!-- Shows if the item is either hidden or visible -->
-                    <statetype name="nodevisibility">
-                        <position>107,7</position>
-                        <state name="hidden">
-                            <shape name="buttoncheck_background" from="base_background_shape">
-                                <area>0,0,36,36</area>
-                                <line color="#AAAAAA" alpha="0" width="0" />
-                            </shape>
-                            <imagetype name="hidden" from="base_icon_selected">
-                                <area>3,3,30,30</area>
-                                <filename>images/icons/hidden.png</filename>
-                            </imagetype>
-                        </state>
-                    </statetype>
-
-                    <!-- Shows the type of the item. It can be either 
-                         a subfolder, upfolder, image or a video -->
-                    <statetype name="nodetype">
-                        <position>0,0</position>
-                        <state name="subfolder">
-                            <shape name="subfolder_background" from="base_background_shape">
-                                <area>7,7,171,40</area>
-                                <line color="#AAAAAA" alpha="0" width="0" />
-                            </shape>
-                            <imagetype name="subfolder_icon">
-                                <area>15,12,30,30</area>
-                                <filename>images/icons/folder_selected.png</filename>
-                            </imagetype>
-                        </state>
-                        <state name="upfolder">
-                            <imagetype name="upfolder_icon">
-                                <area>15,12,30,30</area>
-                                <filename>images/icons/folder_up_selected.png</filename>
-                            </imagetype>
-                        </state>
-                        <!-- Do not show something extra when the file 
-                             is an image. The image preview is enough -->
-                        <state name="image" />
-                        <state name="video">
-                            <imagetype name="videoimage_background">
-                                <area>0,0,185,185</area>
-                                <filename>images/media/image_item_video.png</filename>
-                                <mask>images/media/image_item_fmask.png</mask>
-                            </imagetype>
-                        </state>
-                    </statetype>
-
-                    <imagetype name="background_image_border">
-                        <area>0,0,185,185</area>
-                        <filename>images/media/image_item_fborder.png</filename>
-                    </imagetype>
-
-                    <textarea name="childcount" from="base_textarea" depends="subfolder_icon">
-                        <area>50,12,80,30</area>
-                    </textarea>
-                </state>
-            </statetype>
-        </buttonlist>        
-        
-        
-        <shape name="gallery_info_background" from="base_background_shape">
-            <area>-15,636,1310,70</area>
-        </shape>
-
 
         <!-- shows the name of the folder or image -->
-        <textarea name="title" from="base_textarea">
+        <textarea name="caption" from="base_textarea">
             <area>25,640,770,30</area>
         </textarea>
 
@@ -292,129 +23,110 @@
             <align>right,vcenter</align>
         </textarea>
 
-        <!-- shows path to current image -->
-        <textarea name="breadcrumbs" from="base_textarea">
-            <area>25,670,770,30</area>
-            <scroll direction="horizontal" />
-        </textarea>
-
-        <textarea name="syncprogresstext" from="base_textarea">
-            <area>800,640,300,36</area>
-            <align>right,vcenter</align>
-            <template>Syncing image %1</template>
-        </textarea>
-
-        <textarea name="thumbprogresstext" from="base_textarea">
-            <area>800,670,300,30</area>
-            <align>right,vcenter</align>
-            <template>Creating thumbnail %1</template>
-        </textarea>
-
-    </window>
-
-
-
-
-
-    <!-- Configuration dialog. This is currently
-         used by the MythImage plugin only -->
-    <window name="galleryconfig">
-
-        <!-- the background image -->
-        <imagetype name="background" from="base_background"/>
-
-        <!-- The heading (name) of the screen -->
-        <textarea name="heading" from="base_heading">
-            <position>0,0</position>
-            <textarea name="text">
-                <value>Gallery Settings</value>
-            </textarea>
-        </textarea>
-
-        <!-- the shape where the imagelist is displayed -->
-        <shape name="galleryconfig_background" from="base_background_shape">
-            <area>160,265,960,332</area>
-        </shape>
-
-        <textarea name="sortorder_label">
-            <area>180,280,540,36</area>
-            <align>right,vcenter</align>
-            <value>Sorting order of the shown images:</value>
-        </textarea>
-        <textarea name="slideshowtime_label" from="sortorder_label">
-            <position>180,320</position>
-            <value>Time to display each image during a slideshow (ms):</value>
-        </textarea>
-        <textarea name="transitiontype_label" from="sortorder_label">
-            <position>180,360</position>
-            <value>Type of transition between two images:</value>
-        </textarea>
-        <textarea name="transitiontime_label" from="sortorder_label">
-            <position>180,400</position>
-            <value>Duration of an image transition (ms):</value>
-        </textarea>
-        <textarea name="showhiddenfiles_label" from="sortorder_label">
-            <position>180,440</position>
-            <value>Show files that are marked as hidden:</value>
-        </textarea>
-        <textarea name="cleardatabase_label" from="sortorder_label">
-            <position>180,480</position>
-            <value>Clear database contents (Resync required):</value>
-        </textarea>
-
-        <buttonlist name="sortorder" from="base_selector_wide">
-            <position>730,280</position>
-        </buttonlist>
-        <spinbox name="slideshowtime" from="base_spinbox">
-            <position>730,320</position>
-        </spinbox>
-        <buttonlist name="transitiontype" from="base_selector">
-            <position>730,360</position>
-        </buttonlist>
-        <spinbox name="transitiontime" from="base_spinbox">
-            <position>730,400</position>
-        </spinbox>
-        <checkbox name="showhiddenfiles" from="base_checkbox">
-            <position>730,440</position>
-        </checkbox>
-        <button name="cleardatabase" from="base_button">
-            <area>730,480,36,36</area>
-            <statetype name="buttonstate">
-                <state name="active">
-                    <area>0,0,36,36</area>
+        <!-- Mandatory: the image list 10 columns x 6 rows -->
+        <buttonlist name="images0">
+            <area>10,30,100%-10,100%-30</area>
+            <buttonarea>0,25,100%,100%</buttonarea>
+            <wrapstyle>flowing</wrapstyle>
+            <layout>grid</layout>
+            <arrange>fixed</arrange>
+            <align>allcenter</align>
+            <spacing>0</spacing>  <!-- (100% - 10*10%) / (10-1) or 0% -->
+            <statetype name="buttonitem">
+                <area>0,0,100%,100%</area>
+                <state name="active" from="galleryactivebutton">
+                    <area>0,0,10%,16%</area>
                 </state>
-                <state name="selected">
-                    <area>0,0,36,36</area>
+                <state name="selectedactive" from="galleryselectedbutton">
+                    <area>0,0,10%,16%</area>
                 </state>
-                <state name="disabled">
-                    <area>0,0,36,36</area>
+                <state name="inactive" from="active"/>
+                <state name="selectedinactive" from="active"/>
+            </statetype>
+            <statetype name="upscrollarrow">
+                <position>100%-70,5</position>
+                <state type="off">
+                    <imagetype name="upon">
+                        <filename>lb-uparrow-reg.png</filename>
+                    </imagetype>
                 </state>
-                <state name="pushed">
-                    <area>0,0,36,36</area>
+                <state type="full">
+                    <imagetype name="upoff">
+                        <filename>lb-uparrow-sel.png</filename>
+                    </imagetype>
                 </state>
             </statetype>
-        </button>
-        
-        <shape name="button_separator" from="base_background_shape">
-            <area>161,530,958,1</area>
-        </shape>
-        
-        <button name="save" from="base_button">
-            <position>485,545</position>
-            <value>Save</value>
-        </button>
-        <button name="cancel" from="base_button">
-            <position>650,545</position>
-            <value>Cancel</value>
-        </button>
-        
-        <group name="base_helptext_group" from="base_helptext_group">
-            <position>0,615</position>
-        </group>
+
+            <!-- Show the arrow image that indicates that there are
+                more images below -->
+            <statetype name="downscrollarrow">
+                <position>100%-30,5</position>
+                <state type="off">
+                    <imagetype name="dnon">
+                        <filename>lb-dnarrow-reg.png</filename>
+                    </imagetype>
+                </state>
+                <state type="full">
+                    <imagetype name="dnoff">
+                        <filename>lb-dnarrow-sel.png</filename>
+                    </imagetype>
+                </state>
+            </statetype>
+        </buttonlist>
+
+        <!-- the image list 8 columns x 4 rows -->
+        <buttonlist name="images1" from="images0">
+            <spacing>7</spacing>  <!-- (100% - 8*12%) / (8-1) or 0.57% -->
+            <statetype name="buttonitem">
+                <state name="active" from="galleryactivebutton">
+                    <area>0,0,12%,24%</area>
+                </state>
+                <state name="selectedactive" from="galleryselectedbutton">
+                    <area>0,0,12%,24%</area>
+                </state>
+            </statetype>
+        </buttonlist>
+
+        <!-- the image list 6 columns x 3 rows -->
+        <buttonlist name="images2" from="images0">
+            <spacing>10</spacing>  <!-- (100% - 6*16%) / (6-1) or 0.8% -->
+            <statetype name="buttonitem">
+                <state name="active" from="galleryactivebutton">
+                    <area>0,0,16%,32%</area>
+                </state>
+                <state name="selectedactive" from="galleryselectedbutton">
+                    <area>0,0,16%,32%</area>
+                </state>
+            </statetype>
+        </buttonlist>
+
+        <!-- the image list 4 columns x 2 rows -->
+        <buttonlist name="images3" from="images0">
+            <spacing>0</spacing>  <!-- (100% - 4*25%) / (4-1) or 0% -->
+            <statetype name="buttonitem">
+                <state name="active" from="galleryactivebutton">
+                    <area>0,0,25%,50%</area>
+                </state>
+                <state name="selectedactive" from="galleryselectedbutton">
+                    <area>0,0,25%,50%</area>
+                </state>
+            </statetype>
+        </buttonlist>
+
+        <!-- shows a message when no images are available
+             in the current directory -->
+         <textarea name="noimages" from="basetextarea">
+             <area>0,0,100%,100%</area>
+             <align>allcenter</align>
+             <multiline>yes</multiline>
+         </textarea>
+
+        <!-- Mandatory: Shows file info overlay -->
+        <buttonlist name="infolist" from="galleryinfolist">
+            <drawfrombottom>true</drawfrombottom>
+        </buttonlist>
 
     </window>
-
-
 
 
     <!-- Slideshow window which shows the a single image only or a slideshow.

--- a/music-ui.xml
+++ b/music-ui.xml
@@ -162,8 +162,193 @@
     </window>
 
 
+    <!-- Similar to the playlist view, but with lyrics in place ofthe playlist -->
+    <window name="trackslyricsview" include="base_music.xml">
 
+        <imagetype name="background" from="base_background"/>
 
+        <textarea name="heading" from="base_heading">
+            <position>0,0</position>
+            <textarea name="text">
+                <value>Lyrics View</value>
+            </textarea>
+        </textarea>
+
+        <shape name="lyricslist_background" from="base_background_shape">
+            <area>20,50,1240,430</area>
+	</shape>
+	<!-- The lyrics -->
+	<buttonlist name="lyrics_list">
+	    <!--<area>40,68,1200,370</area>-->
+	    <area>40,68,1200,400</area>
+            <buttonarea>0,0,115,400</buttonarea>
+            <spacing>0</spacing>
+            <layout>vertical</layout>
+            <arrange>stack</arrange>
+            <showarrow>yes</showarrow>
+            <searchposition>-1,410</searchposition>
+            <statetype name="buttonitem">
+                <state name="active">
+                    <area>0,0,100%,30</area>
+                    <textarea name="buttontext">
+                        <area>0,0,100%,100%</area>
+                        <align>left,vcenter</align>
+                        <font>basesmall</font>
+                    </textarea>
+                </state>
+                <state name="selectedactive" from="active">
+                    <textarea name="buttontext">
+                        <area>0,0,100%,100%</area>
+                        <align>left,vcenter</align>
+                        <font>basesmallyellow</font>
+                    </textarea>
+                </state>
+                <state name="selectedinactive" from="selectedactive">
+
+                </state>
+            </statetype>
+        </buttonlist>
+	<statetype name="loading_state">
+            <position>587,167</position>
+            <state name="off"></state>
+            <state name="on">
+		<imagetype name="animation" from="base_icon_selected">
+		    <filename>images/icons/processing.png</filename>
+		    <area>4,4,28,28</area>
+		    <alphapulse min="100" max="220" change="2"/>
+		</imagetype>
+            </state>
+	</statetype>
+
+        <textarea name="status_text" from="basetextarea">
+            <area>100,280,1080,50</area>
+            <font>basemediumyellow</font>
+            <align>center</align>
+        </textarea>
+
+	<!-- From here is as playlist view -->
+
+        <!-- The currently playing track, time, song count
+             and other status information about the playlist -->
+        <shape name="current_playlistinfo_background" from="base_background_shape">
+            <area>-15,490,1310,40</area>
+        </shape>
+        <textarea name="playlisttime" from="base_textarea">
+            <area>765,492,220,36</area>
+            <align>right,vcenter</align>
+        </textarea>
+        <statetype name="repeatstate" from="base_music_repeatstate">
+            <area>992,492,36,36</area>
+        </statetype>
+        <statetype name="shufflestate" from="base_music_shufflestate">
+            <area>1032,492,36,36</area>
+        </statetype>
+        <textarea name="playlistposition" from="base_textarea">
+            <area>1075,492,180,36</area>
+            <align>right,vcenter</align>
+        </textarea>
+
+        <!-- this is the background for the information at the bottom like
+            shows coverart, track details, ratings and the visualizer -->
+        <shape name="trackdetails_background" from="base_background_shape">
+            <area>20,540,1240,165</area>
+        </shape>
+
+        <!-- this is the actual cover image that will be shown if its
+            available, otherwise only the background image is visible -->
+        <imagetype name="coverart_background_image">
+            <area>36,556,133,133</area>
+            <mask>images/media/music_item_nfmask.png</mask>
+            <filename>images/media/music_type/album.png</filename>
+            <preserveaspect>true</preserveaspect>
+        </imagetype>
+        <imagetype name="coverart">
+            <area>36,556,133,133</area>
+            <mask>images/media/music_item_nfmask.png</mask>
+            <preserveaspect>true</preserveaspect>
+        </imagetype>
+        <imagetype name="coverart_border">
+            <area>36,556,133,133</area>
+            <filename>images/media/music_item_nfborder.png</filename>
+        </imagetype>
+
+        <!-- the vertical separator -->
+        <shape name="cover_separator" from="base_background_shape">
+            <area>185,541,1,163</area>
+        </shape>
+
+        <imagetype name="ratingstate_background" from="base_rating_background">
+            <position>980,560</position>
+        </imagetype>
+        <statetype name="ratingstate" from="base_rating">
+            <position>980,560</position>
+        </statetype>
+
+        <textarea name="title" from="base_textarea">
+            <area>200,555,770,30</area>
+            <font>title</font>
+            <scroll direction="horizontal" rate="35"/>
+            <template>%TITLE%</template>
+        </textarea>
+        <textarea name="album" from="base_textarea">
+            <area>200,590,870,30</area>
+            <scroll direction="horizontal" rate="35"/>
+            <template>From the album %ALBUM% by the artist %ARTIST%</template>
+        </textarea>
+        <textarea name="nexttitle" from="base_textarea">
+            <area>200,625,600,30</area>
+            <font>text_grey</font>
+            <scroll direction="horizontal" rate="35"/>
+            <template>Next: %NEXTTITLE% by %NEXTARTIST%</template>
+        </textarea>
+
+        <progressbar name="progress" from="base_progressbar">
+            <position>200,665</position>
+        </progressbar>
+        <textarea name="time" from="base_textarea">
+            <area>715,660,140,30</area>
+        </textarea>
+
+        <textarea name="lastplayed" from="base_textarea">
+            <area>820,625,250,30</area>
+            <align>right,vcenter</align>
+            <template>Last played: %1</template>
+        </textarea>
+        <textarea name="playcount" from="base_textarea">
+            <area>860,660,210,30</area>
+            <align>right,vcenter</align>
+            <template>Played %1 times</template>
+        </textarea>
+
+        <!-- the vertical separator -->
+        <shape name="visualizer_separator" from="base_background_shape">
+            <area>1092,541,1,163</area>
+        </shape>
+
+        <!-- the visualizer and the border around it -->
+        <imagetype name="visualizer_background_image">
+            <area>1110,556,133,133</area>
+            <mask>images/media/music_item_nfmask.png</mask>
+            <filename>images/media/music_visualization_bg.png</filename>
+            <preserveaspect>true</preserveaspect>
+        </imagetype>
+        <video name="visualizer">
+            <area>1110,556,133,133</area>
+            <mask>images/media/music_item_nfmask.png</mask>
+            <preserveaspect>true</preserveaspect>
+        </video>
+        <imagetype name="visualizer_border">
+            <area>1110,556,133,133</area>
+            <filename>images/media/music_item_nfborder.png</filename>
+        </imagetype>
+
+        <!-- This button is not visible and only included to take away
+            the focus from the playlist. If this button has focus
+            then the fast forward and backward action can be used -->
+        <button name="musiccontrols" from="base_button">
+            <position>580,720</position>
+        </button>
+    </window>
 
     <!-- Shows the buttonlist tree at the top and the playlist information
         at the bottom. The user can navigate and select / add music -->

--- a/music-ui.xml
+++ b/music-ui.xml
@@ -162,7 +162,7 @@
     </window>
 
 
-    <!-- Similar to the playlist view, but with lyrics in place ofthe playlist -->
+    <!-- Similar to the playlist view, but with lyrics in place of the playlist -->
     <window name="trackslyricsview" include="base_music.xml">
 
         <imagetype name="background" from="base_background"/>

--- a/music-ui.xml
+++ b/music-ui.xml
@@ -103,7 +103,7 @@
         <textarea name="album" from="base_textarea">
             <area>200,590,870,30</area>
             <scroll direction="horizontal" rate="35"/>
-            <template>From the album %ALBUM% by the artist %ARTIST%</template>
+            <template>By the artist "%ARTIST%" from the album "%ALBUM%"</template>
         </textarea>
         <textarea name="nexttitle" from="base_textarea">
             <area>200,625,600,30</area>
@@ -293,7 +293,7 @@
         <textarea name="album" from="base_textarea">
             <area>200,590,870,30</area>
             <scroll direction="horizontal" rate="35"/>
-            <template>From the album %ALBUM% by the artist %ARTIST%</template>
+            <template>By the artist "%ARTIST%" from the album "%ALBUM%"</template>
         </textarea>
         <textarea name="nexttitle" from="base_textarea">
             <area>200,625,600,30</area>

--- a/music-ui.xml
+++ b/music-ui.xml
@@ -116,16 +116,16 @@
             <position>200,665</position>
         </progressbar>
         <textarea name="time" from="base_textarea">
-            <area>715,660,140,30</area>
+            <area>715,660,125,30</area>
         </textarea>
         
         <textarea name="lastplayed" from="base_textarea">
-            <area>820,625,250,30</area>
+            <area>810,625,260,30</area>
             <align>right,vcenter</align>
             <template>Last played: %1</template>
         </textarea>
         <textarea name="playcount" from="base_textarea">
-            <area>860,660,210,30</area>
+            <area>850,660,220,30</area>
             <align>right,vcenter</align>
             <template>Played %1 times</template>
         </textarea>

--- a/music-ui.xml
+++ b/music-ui.xml
@@ -999,7 +999,7 @@
             <position>580,250</position>
             <value>Compilation Artist:</value>
         </textarea>
-        <textarea name="comilationartist" from="title">
+        <textarea name="compilationartist" from="title">
             <position>790,250</position>
         </textarea>
         


### PR DESCRIPTION
Been sitting on some of these for a while, about time I sent them upstream. I'm running on v30 but looking at:
```console
mythtv$ git log origin/fixes/30..origin/master -- mythtv/themes/default-wide/
```
it doesn't look like too much has changed so the changes ought to be good right up to master.

Here are the individual commit messages for easier reference:
```console
$ git log --no-decorate origin/master..misc-update 
commit 9344971709c5e56845473d083e9407b83ccee9db
Author: Ian Campbell <ijc@hellion.org.uk>
Date:   Sat Mar 21 12:23:59 2020 +0800

    music-ui: adjust artist/album string wording
    
    This is purely a preference thing, but I feel it makes more sense this way
    round especially for compilation albums.
    
    Taking for example the track:
    
        Various Artists - Terrorizer: Fear Candy 92/05-40 Watt Sun - Between Times.flac
    
    Previously:
    
        Between Times
        From the album Terrorizer: Fear Candy 92 by the artist 40 Watt Sun
    
    But the album "Terrorizer: Fear Candy 92" isn't by "40 Watt Sun", it's a
    compilation by various.
    
    Now it reads:
    
        Between Times
        By "40 Watt Sun" from the album "Terrorizer: Fear Candy 92"
    
    Which I think is an improvement.

commit db1bb7c2f4d371b965d94d42b2984d14e09b1bee
Author: Ian Campbell <ijc@hellion.org.uk>
Date:   Sat Mar 21 12:23:01 2020 +0800

    music-ui: typo: compilationartist
    
    The `compilationartist` field in the info view was always empty due to this.

commit 274ba8801f781cdb585e6028fdea6111b0cc36fc
Author: Ian Campbell <ijc@hellion.org.uk>
Date:   Tue Mar 10 17:58:43 2020 +0800

    music-ui: Widen last played and play count boxes
    
    The last played is cut off for me in UK dates ("Fri 31 Aug 2018").
    
    The right edge of the "Next" box (which is to the left of lastg
    played) is at 200+600=800 so this leaves a buffer of 10px before
    the new location at 810.
    
    The right edge of the time box (which is to the left of the play
    count) is at 715+140=855, so drop this to 715+125=840 to allow
    10px before the new location of the play count at 850.

commit 6bfcc021b5387c69acf23b3eac02d5c45659e0d0
Author: Ian Campbell <ijc@hellion.org.uk>
Date:   Fri Dec 21 10:57:40 2018 +0000

    music-ui: Add lyrics view

commit 3f8e6fc7a125291daba87bc0f6be24c11cfe64df
Author: Ian Campbell <ijc@hellion.org.uk>
Date:   Sun Sep 2 17:50:24 2018 +0100

    image-ui: update for modern requirements
    
    I made these changes a long time ago, I believe based on the default theme and
    almost completely replaced the previous code, which didn't work well (I think
    it may have been for the old gallery plugin).
    
    It's not brilliant, but it makes the new gallery functionality basically usable.
```