### PR TITLE
V33: fixes and updates

### DIFF
--- a/base_music.xml
+++ b/base_music.xml
@@ -425,29 +425,33 @@
                         <fill color="#000000" alpha="0" />
                         <cornerradius>0</cornerradius>
                     </shape>
-                    
+
+                    <textarea name="tracknum" from="base_textarea">
+                        <area>50,3,50,30</area>
+                        <template>%DISCNUM%.%TRACKNUM%</template>
+                    </textarea>
                     <textarea name="title" from="base_textarea">
                         <!--<area>8,3,742,30</area>-->
-                        <area>50,3,290,30</area>
+                        <area>110,3,260,30</area>
                         <scroll direction="horizontal" rate="35"/>
                         <template>%TITLE%</template>
                         <!--<template>%TITLE% by %ARTIST% on %ALBUM%</template>-->
                     </textarea>
                     <textarea name="album" from="base_textarea">
-                        <area>350,3,240,30</area>
+                        <area>380,3,225,30</area>
                         <align>right,vcenter</align>
                         <scroll direction="horizontal" rate="35"/>
                         <template>%ALBUM%</template>
                     </textarea>
                     <textarea name="artist" from="base_textarea">
-                        <area>600,3,230,30</area>
+                        <area>615,3,215,30</area>
                         <align>right,vcenter</align>
                         <scroll direction="horizontal" rate="35"/>
                         <template>%ARTIST%</template>
                     </textarea>
                     <textarea name="genre" from="base_textarea">
                         <!--<area>760,3,230,30</area>-->
-                        <area>840,3,170,30</area>
+                        <area>840,3,160,30</area>
                         <align>right,vcenter</align>
                         <scroll direction="horizontal" rate="35"/>
                         <template>%GENRE%</template>

--- a/base_schedule.xml
+++ b/base_schedule.xml
@@ -126,7 +126,7 @@
             <template>Channel: %1</template>
         </textarea>
         <textarea name="timedate" from="base_textarea">
-            <area>900,10,320,36</area>
+            <area>900,10,325,36</area>
             <align>right,vcenter</align>
         </textarea>
         <textarea name="rectypestatus" from="base_textarea">

--- a/base_schedule.xml
+++ b/base_schedule.xml
@@ -128,7 +128,6 @@
         <textarea name="timedate" from="base_textarea">
             <area>900,10,320,36</area>
             <align>right,vcenter</align>
-            <cutdown>yes</cutdown>
         </textarea>
         <textarea name="rectypestatus" from="base_textarea">
             <area>825,40,400,36</area>

--- a/base_schedule.xml
+++ b/base_schedule.xml
@@ -116,7 +116,7 @@
             <scroll direction="horizontal" rate="35"/>
         </textarea>
         <textarea name="template" from="base_textarea">
-            <area>625,10,300,36</area>
+            <area>625,10,270,36</area>
             <scroll direction="horizontal" rate="35"/>
             <template>%Using |TEMPLATE| Template%</template>
         </textarea>
@@ -126,7 +126,7 @@
             <template>Channel: %1</template>
         </textarea>
         <textarea name="timedate" from="base_textarea">
-            <area>945,10,280,36</area>
+            <area>900,10,320,36</area>
             <align>right,vcenter</align>
             <cutdown>yes</cutdown>
         </textarea>

--- a/music-ui.xml
+++ b/music-ui.xml
@@ -1011,12 +1011,13 @@
             <position>790,280</position>
         </textarea>
         
-        <textarea name="tracknum_label" from="title_label">
+        <textarea name="discnum_label" from="title_label">
             <position>580,310</position>
-            <value>Track No.:</value>
+            <value>Disc:</value>
         </textarea>
-        <textarea name="tracknum" from="title">
+        <textarea name="discnum" from="title">
             <position>790,310</position>
+            <value>%DISCNUM%/%DISCCOUNT%</value>
         </textarea>        
         <textarea name="length" from="title">
             <position>870,310</position>
@@ -1027,12 +1028,13 @@
             <template>Year: %1</template>
         </textarea>
 
-        <textarea name="trackcount_label" from="title_label">
+        <textarea name="tracknum_label" from="title_label">
             <position>580,340</position>
-            <value>Track Count:</value>
+            <value>Track:</value>
         </textarea>
-        <textarea name="trackcount" from="title">
+        <textarea name="tracknum" from="title">
             <position>790,340</position>
+            <value>%TRACKNUM%/%TRACKCOUNT%</value>
         </textarea>
 
         <!-- separates the title, album and artist information from the rest -->

--- a/music-ui.xml
+++ b/music-ui.xml
@@ -176,11 +176,11 @@
 
         <shape name="lyricslist_background" from="base_background_shape">
             <area>20,50,1240,430</area>
-	</shape>
-	<!-- The lyrics -->
-	<buttonlist name="lyrics_list">
-	    <!--<area>40,68,1200,370</area>-->
-	    <area>40,68,1200,400</area>
+        </shape>
+        <!-- The lyrics -->
+        <buttonlist name="lyrics_list">
+            <!--<area>40,68,1200,370</area>-->
+            <area>40,68,1200,400</area>
             <buttonarea>0,0,115,400</buttonarea>
             <spacing>0</spacing>
             <layout>vertical</layout>
@@ -208,17 +208,17 @@
                 </state>
             </statetype>
         </buttonlist>
-	<statetype name="loading_state">
+        <statetype name="loading_state">
             <position>587,167</position>
             <state name="off"></state>
             <state name="on">
-		<imagetype name="animation" from="base_icon_selected">
-		    <filename>images/icons/processing.png</filename>
-		    <area>4,4,28,28</area>
-		    <alphapulse min="100" max="220" change="2"/>
-		</imagetype>
+                <imagetype name="animation" from="base_icon_selected">
+                    <filename>images/icons/processing.png</filename>
+                    <area>4,4,28,28</area>
+                    <alphapulse min="100" max="220" change="2"/>
+                </imagetype>
             </state>
-	</statetype>
+        </statetype>
 
         <textarea name="status_text" from="basetextarea">
             <area>100,280,1080,50</area>
@@ -226,7 +226,7 @@
             <align>center</align>
         </textarea>
 
-	<!-- From here is as playlist view -->
+        <!-- From here is as playlist view -->
 
         <!-- The currently playing track, time, song count
              and other status information about the playlist -->

--- a/music-ui.xml
+++ b/music-ui.xml
@@ -103,7 +103,7 @@
         <textarea name="album" from="base_textarea">
             <area>200,590,870,30</area>
             <scroll direction="horizontal" rate="35"/>
-            <template>By the artist "%ARTIST%" from the album "%ALBUM%"</template>
+            <template>By the artist “%ARTIST%” from the album “%ALBUM%”</template>
         </textarea>
         <textarea name="nexttitle" from="base_textarea">
             <area>200,625,560,30</area>
@@ -293,7 +293,7 @@
         <textarea name="album" from="base_textarea">
             <area>200,590,870,30</area>
             <scroll direction="horizontal" rate="35"/>
-            <template>By the artist "%ARTIST%" from the album "%ALBUM%"</template>
+            <template>By the artist “%ARTIST%” from the album “%ALBUM%”</template>
         </textarea>
         <textarea name="nexttitle" from="base_textarea">
             <area>200,625,560,30</area>

--- a/music-ui.xml
+++ b/music-ui.xml
@@ -106,7 +106,7 @@
             <template>By the artist "%ARTIST%" from the album "%ALBUM%"</template>
         </textarea>
         <textarea name="nexttitle" from="base_textarea">
-            <area>200,625,600,30</area>
+            <area>200,625,560,30</area>
             <font>text_grey</font>
             <scroll direction="horizontal" rate="35"/>
             <template>Next: %NEXTTITLE% by %NEXTARTIST%</template>
@@ -120,7 +120,7 @@
         </textarea>
         
         <textarea name="lastplayed" from="base_textarea">
-            <area>810,625,260,30</area>
+            <area>770,625,300,30</area>
             <align>right,vcenter</align>
             <template>Last played: %1</template>
         </textarea>
@@ -296,7 +296,7 @@
             <template>By the artist "%ARTIST%" from the album "%ALBUM%"</template>
         </textarea>
         <textarea name="nexttitle" from="base_textarea">
-            <area>200,625,600,30</area>
+            <area>200,625,560,30</area>
             <font>text_grey</font>
             <scroll direction="horizontal" rate="35"/>
             <template>Next: %NEXTTITLE% by %NEXTARTIST%</template>
@@ -310,7 +310,7 @@
         </textarea>
 
         <textarea name="lastplayed" from="base_textarea">
-            <area>820,625,250,30</area>
+            <area>770,625,300,30</area>
             <align>right,vcenter</align>
             <template>Last played: %1</template>
         </textarea>

--- a/musicsettings-ui.xml
+++ b/musicsettings-ui.xml
@@ -138,39 +138,63 @@
         </textarea>
 
         <shape name="playersettings_background" from="base_background_shape">
-            <area>285,345,710,252</area>
+            <area>285,225,710,372</area>
         </shape>
 
         <textarea name="resumemode_label" from="base_textarea">
-            <area>300,360,300,36</area>
+            <area>300,240,300,36</area>
             <align>right,vcenter</align>
-            <value>Resume mode:</value>
+            <value>Resume mode (Playlist):</value>
         </textarea>
         <buttonlist name="resumemode" from="base_selector">
-            <position>610,360</position>
+            <position>610,240</position>
+        </buttonlist>
+
+        <textarea name="resumemodeeditor_label" from="resumemode_label">
+            <position>300,280</position>
+            <value>Resume mode (Playlist Editor):</value>
+        </textarea>
+        <buttonlist name="resumemodeeditor" from="base_selector">
+            <position>610,280</position>
+        </buttonlist>
+
+        <textarea name="resumemoderadio_label" from="resumemode_label">
+            <position>300,320</position>
+            <value>Resume mode (Radio):</value>
+        </textarea>
+        <buttonlist name="resumemoderadio" from="base_selector">
+            <position>610,320</position>
         </buttonlist>
 
         <textarea name="exitaction_label" from="resumemode_label">
-            <position>300,400</position>
+            <position>300,360</position>
             <value>Action on exit:</value>
         </textarea>
-        <buttonlist name="exitaction" from="base_selector_wide">
+        <buttonlist name="exitaction" from="base_selector">
+            <position>610,360</position>
+        </buttonlist>
+
+        <textarea name="jumpaction_label" from="resumemode_label">
+            <position>300,400</position>
+            <value>Action on jumppoint:</value>
+        </textarea>
+        <buttonlist name="jumpaction" from="base_selector">
             <position>610,400</position>
         </buttonlist>
 
-        <textarea name="autolookupcd_label" from="resumemode_label">
-            <position>300,440</position>
-            <value>Automatically lookup CDs:</value>
-        </textarea>
-        <checkbox name="autolookupcd" from="base_checkbox">
-            <position>610,440</position>
-        </checkbox>
-
         <textarea name="autoplaycd_label" from="resumemode_label">
-            <position>300,480</position>
+            <position>300,440</position>
             <value>Automatically Play CDs:</value>
         </textarea>
         <checkbox name="autoplaycd" from="base_checkbox">
+            <position>610,440</position>
+        </checkbox>
+
+        <textarea name="autolookupcd_label" from="resumemode_label">
+            <position>300,480</position>
+            <value>Automatically lookup CDs:</value>
+        </textarea>
+        <checkbox name="autolookupcd" from="base_checkbox">
             <position>610,480</position>
         </checkbox>
 

--- a/osd.xml
+++ b/osd.xml
@@ -273,7 +273,7 @@
         </shape>
 
         <textarea name="title">
-            <area>235,607,260,36</area>
+            <area>235,607,380,36</area>
             <align>left,vcenter</align>
             <multiline>no</multiline>
             <cutdown>no</cutdown>
@@ -281,13 +281,8 @@
             <font>text</font>
         </textarea>
         
-        <textarea name="recordedtime" from="title">
-            <area>505,607,260,36</area>
-            <align>hcenter,vcenter</align>
-        </textarea>
-
         <textarea name="description" from="title">
-            <area>775,607,260,36</area>
+            <area>640,607,395,36</area>
             <align>right,vcenter</align>
             <template>%PLAYEDTIME% of %TOTALTIME% %(|REMAININGTIME| remaining)%%(|BEHINDTIME| behind)%</template>
         </textarea>

--- a/osd.xml
+++ b/osd.xml
@@ -358,7 +358,7 @@
         <textarea name="starttime" from="title">
             <area>120,495,400,36</area>
             <font>text</font>
-            <template>%STARTTIME%-%ENDTIME% : %LENMINS%</template>
+            <template>%STARTDATE% %STARTTIME%-%ENDTIME% : %LENMINS%</template>
         </textarea>
 
         <!-- separates the title and channel and the 

--- a/osd.xml
+++ b/osd.xml
@@ -289,7 +289,7 @@
         <textarea name="description" from="title">
             <area>775,607,260,36</area>
             <align>right,vcenter</align>
-            <template>%DESCRIPTION% %VALUE%%UNITS%</template>
+            <template>%PLAYEDTIME% of %TOTALTIME% %(|REMAININGTIME| remaining)%%(|BEHINDTIME| behind)%</template>
         </textarea>
 
         <progressbar name="position">


### PR DESCRIPTION
I've been running most of these on V32 for quite a while, some are just personal preferences (e.g. using posh quotes and including the disc number) others are tweak for cut off text, alignment etc.

I'm now running V33 and this exposed some errors when trying to access the music settings for the player. It looks like the theme here actually changed in 2014/2015 (https://github.com/MythTV/mythtv/commit/d9c6036f626d4b0e0e7eafed0001fad397450abf and https://github.com/MythTV/mythtv/commit/f64b513401d9278ad8ac202f942e06a525a62035 I think is most of them)  so I don't know if this was broken for several releases (perhaps as long ago as V28) and I didn't notice (it's not a screen one visits very often) or if something in V33 got stricter.